### PR TITLE
Prevent escaping placeholder image attributes

### DIFF
--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -11,5 +11,5 @@ $shouldLoad = $shouldLoad ?? true;
     @isset($sizes) sizes="{{$sizes}}" @endisset
     @isset($alt) alt="{{$alt}}" @endisset
     @isset($style) style="{{$style}}" @endisset
-    @isset($attributes) {{$attributes}} @endisset
+    @isset($attributes) {!! $attributes !!} @endisset
 />

--- a/resources/views/placeholder.blade.php
+++ b/resources/views/placeholder.blade.php
@@ -10,5 +10,5 @@ $attributes = 'aria-hidden="true" data-placeholder-image';
       'style' => $style,
   ])
 @else
-    <div style="{{$style}}" {{$attributes}}></div>
+    <div style="{{$style}}" {!! $attributes !!}></div>
 @endif


### PR DESCRIPTION
This fixes the issue where the `aria-hidden` attribute is being escaped so renders as `aria-hidden=&quot;true&quot;`.